### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ These will output:
 
 ```
 ~ INFO -- Here's a generic log message!
-~ ERROR -- an error happened -- userID=1111 err=some-error sky=blue
+~ ERROR -- an error happened -- userID="1111" err="some error" sky="blue"
 ```

--- a/llog.go
+++ b/llog.go
@@ -157,7 +157,8 @@ func (e entry) printOut(w io.Writer, displayTS bool) error {
 			err = writeHelper(space, w, err)
 			err = writeHelper([]byte(k), w, err)
 			err = writeHelper(equals, w, err)
-			err = writeHelper([]byte(fmt.Sprint(v)), w, err)
+			vstr := fmt.Sprint(v)
+			err = writeHelper([]byte(fmt.Sprintf("%q", vstr)), w, err)
 		}
 	}
 	err = writeHelper(newline, w, err)


### PR DESCRIPTION
- Fatal needs to block till it's sure that the message has been printed, then call `os.Exit` itself. Otherwise if you call fatal as the last statement in main it would never print or do the `os.Exit` call.
- Quote the values when printing the KV pairs
