### PR TITLE
copy the KV entry passed in, otherwise it could be modified from the caller while it's being printed

### DIFF
--- a/llog.go
+++ b/llog.go
@@ -218,7 +218,11 @@ func init() {
 
 func kvNormalize(kv []KV) KV {
 	if len(kv) > 0 {
-		return kv[0]
+		kvCopy := make(KV, len(kv[0]))
+		for k, v := range kv[0] {
+			kvCopy[k] = v
+		}
+		return kvCopy
 	}
 	return nil
 }


### PR DESCRIPTION
When one of the llog commands is made and a KV is passed in the log command is passed into a channel to be actually processed. At this point the caller of llog is free to modify the KV they passed in. Since KVs are maps, and maps are references, this means that as llog is printing out a KV the caller could be modifying it at the same time, which can cause problems.

The two solutions are to either make a copy of the KV when it's passed, or to have llog calls block until they are finished printing. The second seems worse to me, even though copying isn't super great. In reality most of the things which get passed into KV are either strings or errors. Strings are immutable so they aren't _really_ copied in most cases. Errors are interfaces and are therefore references, so they aren't really copied either. So I think the copying strategy is the less horrible overall.
